### PR TITLE
Change minor mode init-value to nil.

### DIFF
--- a/ruby-block.el
+++ b/ruby-block.el
@@ -105,7 +105,7 @@ t          => minibuffer and overlay"
 (define-minor-mode ruby-block-mode
   "In ruby-mode, Displays the line where there is keyword corresponding
 to END keyword. this is Minor mode for ruby-mode only."
-  :init-value t
+  :init-value nil
   :global nil
   :keymap nil
   :lighter " RBlock"


### PR DESCRIPTION
According to the [Emacs documentation](http://www.gnu.org/software/emacs/manual/html_node/elisp/Defining-Minor-Modes.html), the `:init-value` for the minor mode should almost always be `nil`.

In this case, not setting it to `nil` is causing the ruby-block minor mode to be enabled in all buffers once ruby-block is enabled.
